### PR TITLE
Add theme selection for SVG exports

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -59,7 +59,8 @@ jobs:
           fi
       - uses: actions/configure-pages@v5
       - uses: astral-sh/setup-uv@v7
-      - env:
+      - name: Build documentation for current ref
+        env:
           FORCE_COLOR: 1
           COLUMNS: 90
           UV_COLOR: always
@@ -67,17 +68,31 @@ jobs:
         run: |
           unset NO_COLOR
           make docs
+          mv docs/_build/html docs/_build/html-current
+      - name: Build stable documentation from main
+        if: github.event_name == 'pull_request'
+        env:
+          FORCE_COLOR: 1
+          COLUMNS: 90
+          UV_COLOR: always
+        run: |
+          git fetch origin main --depth=1
+          git worktree add ../richterm-main origin/main
+          cd ../richterm-main
+          unset NO_COLOR
+          PYTHONPATH=src make docs
       - name: Stage documentation artifact
         run: |
           out_dir="site"
           subdir="${{ steps.preview.outputs.docs_subdir }}"
           rm -rf "$out_dir"
+          mkdir -p "$out_dir"
           if [ -n "$subdir" ]; then
+            cp -a ../richterm-main/docs/_build/html/. "$out_dir/"
             mkdir -p "$out_dir/$subdir"
-            cp -a docs/_build/html/. "$out_dir/$subdir/"
+            cp -a docs/_build/html-current/. "$out_dir/$subdir/"
           else
-            mkdir -p "$out_dir"
-            cp -a docs/_build/html/. "$out_dir/"
+            cp -a docs/_build/html-current/. "$out_dir/"
           fi
       - uses: actions/upload-pages-artifact@v4
         with:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,12 +19,14 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 extensions = [
     "myst_parser",
     "sphinxcontrib.mermaid",
+    "sphinx_tabs.tabs",
     "richterm.sphinxext",
 ]
 
 richterm_prompt = "[bold]$"
 richterm_hide_command = False
 richterm_shown_command = None
+richterm_theme = "default"
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,4 +1,4 @@
-# Configuration (Reference)
+# Configuration
 
 This chapter is a lookup reference for environment variables that affect `richterm` behavior directly.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -3,6 +3,11 @@
 This chapter is a lookup reference for environment variables that affect `richterm` behavior directly.
 
 ```{glossary}
+RICHTERM_THEME
+  Sets the default SVG terminal theme for `richterm`.
+  Supported values are `default`, `monokai`, `dimmed-monokai`, `night-owlish`, and `svg-export`.
+  The command-line `--theme` option and the directive `:theme:` option take precedence over this environment variable.
+
 RICHTERM_DISABLE_COLOR_HINT
   Disables the extra color-friendly environment hints that `richterm` normally injects before running a command.
   When set to `1`, `richterm` leaves the child environment unchanged.
@@ -18,5 +23,5 @@ FORCE_COLOR
 
 TERM
   Terminal capability identifier passed to the executed command.
-  If `TERM` is missing or set to `dumb`, `richterm` defaults it to `xterm-256color` to improve captured styling.
+  If it is missing or set to `dumb`, `richterm` defaults it to `xterm-256color` to improve captured styling.
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,7 +5,7 @@ This chapter is a lookup reference for environment variables that affect `richte
 ```{glossary}
 RICHTERM_THEME
   Sets the default SVG terminal theme for `richterm`.
-  Supported values are `default`, `monokai`, `dimmed-monokai`, `night-owlish`, and `svg-export`.
+  Supported values are `default`, `light`, `monokai`, `dimmed-monokai`, `night-owlish`, and `svg-export`.
   The command-line `--theme` option and the directive `:theme:` option take precedence over this environment variable.
 
 RICHTERM_DISABLE_COLOR_HINT

--- a/docs/development_workflow.md
+++ b/docs/development_workflow.md
@@ -1,4 +1,4 @@
-# Development Workflow (How-to)
+# Development Workflow
 
 ```{include} ../CONTRIBUTING.md
 ```

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -22,10 +22,11 @@ uvx richterm -o demo.svg python -c "print('hello')"
 
 ## 3. Customize what appears in the transcript
 
-You can tweak the prompt, hide the command, or show a friendlier command than the one actually executed:
+You can tweak the prompt, pick a different export theme, hide the command, or show a friendlier command than the one actually executed:
 
 ```bash
 uvx richterm --prompt "[bold blue]$" git status --short
+uvx richterm --theme monokai python -m rich --force-terminal rainbow
 uvx richterm --hide-command python -c "print('secret command')"
 uvx richterm --shown-command "pytest -q" python -c "print('fixture output')"
 ```

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,4 +1,4 @@
-# Getting Started (Tutorial)
+# Getting Started
 
 This tutorial walks through the main user-facing flow: run `richterm`, generate an SVG, and then install it permanently if you want it around.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,12 +24,14 @@ uvx richterm
 Key options:
 
 - `--prompt`: Rich markup shown before the command (defaults to `$`).
+- `--theme`: choose the Rich terminal export theme (`default`, `monokai`, `dimmed-monokai`, `night-owlish`, or `svg-export`).
 - `--hide-command`: omit the prompt/command from the SVG.
 - `-o/--output`: select the SVG destination; otherwise `rich_term_<TIMESTAMP>.svg` is created in the working directory.
 - `--shown-command`: render a different command string than the one executed (useful when the real invocation is noisy or repetitive).
 
-Rich output is encouraged automatically: unless you opt out, the command runs with colour-friendly hints (`TERM`, `FORCE_COLOR`, `CLICOLOR_FORCE`, `PY_COLORS`, `TTY_COMPATIBLE`).
-Set `RICHTERM_DISABLE_COLOR_HINT=1` or export `NO_COLOR` to skip these tweaks. If your CI sets `NO_COLOR` but you still want colour, export `FORCE_COLOR=1`.
+Rich output is encouraged automatically: unless you opt out, the command runs with colour-friendly hints ({term}`TERM`, {term}`FORCE_COLOR`, `CLICOLOR_FORCE`, `PY_COLORS`, `TTY_COMPATIBLE`).
+Set {term}`RICHTERM_THEME` to change the default export theme for both the CLI and Sphinx builds.
+Set {term}`RICHTERM_DISABLE_COLOR_HINT` to `1` or export {term}`NO_COLOR` to skip these tweaks. If your CI sets {term}`NO_COLOR` but you still want colour, export {term}`FORCE_COLOR` to `1`.
 
 To install the tool permanently:
 
@@ -49,6 +51,7 @@ extensions = [
 ]
 richterm_prompt = "[bold]$"
 richterm_hide_command = False
+richterm_theme = "default"
 # Optional default text to display instead of the executed command
 richterm_shown_command = None
 ```
@@ -57,6 +60,7 @@ Use the directive inside MyST Markdown:
 
 ````md
 ```{richterm} python -m rich --force-terminal rainbow
+:theme: monokai
 ```
 ````
 
@@ -64,11 +68,39 @@ Or in reStructuredText:
 
 ```rst
 .. richterm:: python -m rich --force-terminal rainbow
+:theme: monokai
 :shown-command: python -m rich rainbow
 ```
 
-The directive executes the command during the build, embeds the SVG directly in HTML output, and falls back to a literal code block elsewhere. Override the prompt per block with `:prompt:`, hide the command with `:hide-command:`, or swap the displayed command while running another with `:shown-command:` (falls back to `richterm_shown_command` if set).
+The directive executes the command during the build, embeds the SVG directly in HTML output, and falls back to a literal code block elsewhere. Override the prompt per block with `:prompt:`, choose a terminal palette with `:theme:`, hide the command with `:hide-command:`, or swap the displayed command while running another with `:shown-command:` (falls back to `richterm_shown_command` if set).
 If you hide the command, any `:shown-command:` value is ignored and a warning is emitted.
+
+### Same output, different themes
+
+The same ANSI-rich output can be rendered with different terminal themes:
+
+`````{tabs}
+````{tab} default
+```{richterm} env PYTHONPATH=../src uv run python -c "from rich.console import Console; from rich.table import Table; console = Console(force_terminal=True); table = Table(title='Status'); table.add_column('Name', style='cyan'); table.add_column('State'); table.add_column('Value', justify='right', style='magenta'); table.add_row('build', '[green]ok[/green]', '42'); table.add_row('tests', '[yellow]warn[/yellow]', '3'); table.add_row('deploy', '[red]fail[/red]', '1'); console.print(table)"
+:shown-command: python demo.py
+:theme: default
+```
+````
+
+````{tab} monokai
+```{richterm} env PYTHONPATH=../src uv run python -c "from rich.console import Console; from rich.table import Table; console = Console(force_terminal=True); table = Table(title='Status'); table.add_column('Name', style='cyan'); table.add_column('State'); table.add_column('Value', justify='right', style='magenta'); table.add_row('build', '[green]ok[/green]', '42'); table.add_row('tests', '[yellow]warn[/yellow]', '3'); table.add_row('deploy', '[red]fail[/red]', '1'); console.print(table)"
+:shown-command: python demo.py
+:theme: monokai
+```
+````
+
+````{tab} night-owlish
+```{richterm} env PYTHONPATH=../src uv run python -c "from rich.console import Console; from rich.table import Table; console = Console(force_terminal=True); table = Table(title='Status'); table.add_column('Name', style='cyan'); table.add_column('State'); table.add_column('Value', justify='right', style='magenta'); table.add_row('build', '[green]ok[/green]', '42'); table.add_row('tests', '[yellow]warn[/yellow]', '3'); table.add_row('deploy', '[red]fail[/red]', '1'); console.print(table)"
+:shown-command: python demo.py
+:theme: night-owlish
+```
+````
+`````
 
 ## Documentation Map (Diataxis)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -81,35 +81,26 @@ The same ANSI-rich output can be rendered with different terminal themes:
 
 `````{tabs}
 ````{tab} default
-```{richterm} env PYTHONPATH=../src uv run python -c "from rich.console import Console; from rich.table import Table; console = Console(force_terminal=True); table = Table(title='Status'); table.add_column('Name', style='cyan'); table.add_column('State'); table.add_column('Value', justify='right', style='magenta'); table.add_row('build', '[green]ok[/green]', '42'); table.add_row('tests', '[yellow]warn[/yellow]', '3'); table.add_row('deploy', '[red]fail[/red]', '1'); console.print(table)"
-:shown-command: python demo.py
+```{richterm} env PYTHONPATH=../src uv run python -m rich --force-terminal rainbow
+:shown-command: python -m rich rainbow
 :theme: default
 ```
 ````
 
 ````{tab} monokai
-```{richterm} env PYTHONPATH=../src uv run python -c "from rich.console import Console; from rich.table import Table; console = Console(force_terminal=True); table = Table(title='Status'); table.add_column('Name', style='cyan'); table.add_column('State'); table.add_column('Value', justify='right', style='magenta'); table.add_row('build', '[green]ok[/green]', '42'); table.add_row('tests', '[yellow]warn[/yellow]', '3'); table.add_row('deploy', '[red]fail[/red]', '1'); console.print(table)"
-:shown-command: python demo.py
+```{richterm} env PYTHONPATH=../src uv run python -m rich --force-terminal rainbow
+:shown-command: python -m rich rainbow
 :theme: monokai
 ```
 ````
 
 ````{tab} night-owlish
-```{richterm} env PYTHONPATH=../src uv run python -c "from rich.console import Console; from rich.table import Table; console = Console(force_terminal=True); table = Table(title='Status'); table.add_column('Name', style='cyan'); table.add_column('State'); table.add_column('Value', justify='right', style='magenta'); table.add_row('build', '[green]ok[/green]', '42'); table.add_row('tests', '[yellow]warn[/yellow]', '3'); table.add_row('deploy', '[red]fail[/red]', '1'); console.print(table)"
-:shown-command: python demo.py
+```{richterm} env PYTHONPATH=../src uv run python -m rich --force-terminal rainbow
+:shown-command: python -m rich rainbow
 :theme: night-owlish
 ```
 ````
 `````
-
-## Documentation Map (Diataxis)
-
-This project follows the [Diataxis](https://diataxis.fr/) framework:
-
-- Tutorials: learning-oriented, step-by-step.
-- How-to guides: goal-oriented operational procedures.
-- Reference: factual, lookup-first technical details.
-- Explanation: context, rationale, and design choices.
 
 ```{toctree}
 :maxdepth: 2

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ uvx richterm
 Key options:
 
 - `--prompt`: Rich markup shown before the command (defaults to `$`).
-- `--theme`: choose the Rich terminal export theme (`default`, `monokai`, `dimmed-monokai`, `night-owlish`, or `svg-export`).
+- `--theme`: choose the Rich terminal export theme (`default`, `light`, `monokai`, `dimmed-monokai`, `night-owlish`, or `svg-export`).
 - `--hide-command`: omit the prompt/command from the SVG.
 - `-o/--output`: select the SVG destination; otherwise `rich_term_<TIMESTAMP>.svg` is created in the working directory.
 - `--shown-command`: render a different command string than the one executed (useful when the real invocation is noisy or repetitive).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,7 @@ docs = [
     "sphinx-book-theme>=1.1.0",
     "sphinxcontrib-mermaid>=1.0.0",
     "richterm[sphinx]>=0.1.0",
+    "sphinx-tabs>=3.5.0",
 ]
 dev = [
     { include-group = "test" },

--- a/src/richterm/__init__.py
+++ b/src/richterm/__init__.py
@@ -12,8 +12,12 @@ from pathlib import Path
 
 from ._core import (
     CommandExecutionError,
+    InvalidThemeError,
     RenderOptions,
+    available_terminal_themes,
     command_to_display,
+    default_terminal_theme_name,
+    normalize_terminal_theme,
     render_svg,
     run_command,
 )
@@ -60,6 +64,16 @@ def get_parser() -> argparse.ArgumentParser:
         default="$",
         help="Prompt to display before the command. Accepts Rich markup.",
     )
+    parser.add_argument(
+        "--theme",
+        default=None,
+        metavar="THEME",
+        help=(
+            "Terminal theme used for SVG export. "
+            f"Supported values: {', '.join(available_terminal_themes())}. "
+            "Defaults to $RICHTERM_THEME or 'default'."
+        ),
+    )
     visibility.add_argument(
         "--shown-command",
         dest="shown_command",
@@ -80,6 +94,7 @@ class CLIOptions:
     hide_command: bool
     output: Path | None
     shown_command: str | None
+    theme: str
 
 
 def _parse_args(args: Sequence[str] | None) -> CLIOptions:
@@ -87,12 +102,17 @@ def _parse_args(args: Sequence[str] | None) -> CLIOptions:
     parsed = parser.parse_args(args=args)
     if not parsed.command:
         parser.error("a command to execute is required")
+    try:
+        theme = normalize_terminal_theme(parsed.theme or default_terminal_theme_name())
+    except InvalidThemeError as exc:
+        parser.error(str(exc))
     return CLIOptions(
         command=parsed.command,
         prompt=parsed.prompt,
         hide_command=parsed.hide_command,
         output=parsed.output,
         shown_command=parsed.shown_command,
+        theme=theme,
     )
 
 
@@ -117,7 +137,7 @@ def main(args: Sequence[str] | None = None) -> int:
     svg = render_svg(
         command_display,
         transcript,
-        RenderOptions(prompt=options.prompt, hide_command=options.hide_command),
+        RenderOptions(prompt=options.prompt, hide_command=options.hide_command, theme=options.theme),
     )
     output_path.write_text(svg, encoding="utf-8")
 

--- a/src/richterm/_core.py
+++ b/src/richterm/_core.py
@@ -54,7 +54,8 @@ _COLOR_ENV_DEFAULTS: dict[str, str] = {
 }
 
 _TERMINAL_THEMES: dict[str, TerminalTheme] = {
-    "default": DEFAULT_TERMINAL_THEME,
+    "default": SVG_EXPORT_THEME,
+    "light": DEFAULT_TERMINAL_THEME,
     "monokai": MONOKAI,
     "dimmed-monokai": DIMMED_MONOKAI,
     "night-owlish": NIGHT_OWLISH,

--- a/src/richterm/_core.py
+++ b/src/richterm/_core.py
@@ -39,6 +39,12 @@ class CommandExecutionError(RuntimeError):
 class InvalidThemeError(ValueError):
     """Raised when a requested terminal theme is not supported."""
 
+    def __init__(self, theme: str, available_themes: Sequence[str]) -> None:
+        self.theme = theme
+        self.available_themes = tuple(available_themes)
+        available = ", ".join(self.available_themes)
+        super().__init__(f"Unknown theme '{theme}'. Available themes: {available}")
+
 
 _COLOR_ENV_DEFAULTS: dict[str, str] = {
     "FORCE_COLOR": "1",
@@ -76,8 +82,7 @@ def normalize_terminal_theme(theme: str) -> str:
     if normalized in _TERMINAL_THEMES:
         return normalized
 
-    available = ", ".join(available_terminal_themes())
-    raise InvalidThemeError(f"Unknown theme '{theme}'. Available themes: {available}")
+    raise InvalidThemeError(theme, available_terminal_themes())
 
 
 def get_terminal_theme(theme: str) -> TerminalTheme:

--- a/src/richterm/_core.py
+++ b/src/richterm/_core.py
@@ -12,6 +12,14 @@ from pathlib import Path
 from subprocess import CompletedProcess
 
 from rich.console import Console
+from rich.terminal_theme import (
+    DEFAULT_TERMINAL_THEME,
+    DIMMED_MONOKAI,
+    MONOKAI,
+    NIGHT_OWLISH,
+    SVG_EXPORT_THEME,
+    TerminalTheme,
+)
 from rich.text import Text
 
 
@@ -21,10 +29,15 @@ class RenderOptions:
 
     prompt: str = "$"
     hide_command: bool = False
+    theme: str = "default"
 
 
 class CommandExecutionError(RuntimeError):
     """Raised when a command cannot be executed."""
+
+
+class InvalidThemeError(ValueError):
+    """Raised when a requested terminal theme is not supported."""
 
 
 _COLOR_ENV_DEFAULTS: dict[str, str] = {
@@ -33,6 +46,44 @@ _COLOR_ENV_DEFAULTS: dict[str, str] = {
     "PY_COLORS": "1",
     "TTY_COMPATIBLE": "1",
 }
+
+_TERMINAL_THEMES: dict[str, TerminalTheme] = {
+    "default": DEFAULT_TERMINAL_THEME,
+    "monokai": MONOKAI,
+    "dimmed-monokai": DIMMED_MONOKAI,
+    "night-owlish": NIGHT_OWLISH,
+    "svg-export": SVG_EXPORT_THEME,
+}
+
+
+def available_terminal_themes() -> tuple[str, ...]:
+    """Return the supported terminal theme names."""
+
+    return tuple(_TERMINAL_THEMES)
+
+
+def default_terminal_theme_name(env: Mapping[str, str] | None = None) -> str:
+    """Return the default terminal theme name from *env* or the built-in fallback."""
+
+    env_vars = os.environ if env is None else env
+    return env_vars.get("RICHTERM_THEME", "default")
+
+
+def normalize_terminal_theme(theme: str) -> str:
+    """Return a canonical theme name or raise if it is unsupported."""
+
+    normalized = theme.strip().lower().replace("_", "-")
+    if normalized in _TERMINAL_THEMES:
+        return normalized
+
+    available = ", ".join(available_terminal_themes())
+    raise InvalidThemeError(f"Unknown theme '{theme}'. Available themes: {available}")
+
+
+def get_terminal_theme(theme: str) -> TerminalTheme:
+    """Resolve *theme* to a Rich terminal theme."""
+
+    return _TERMINAL_THEMES[normalize_terminal_theme(theme)]
 
 
 def _prepare_environment(env: Mapping[str, str] | None) -> dict[str, str]:
@@ -106,7 +157,7 @@ def render_svg(command_display: str | None, output: str, options: RenderOptions)
     if output:
         console.print(Text.from_ansi(output), end="")
 
-    return console.export_svg(title="")
+    return console.export_svg(title="", theme=get_terminal_theme(options.theme))
 
 
 def command_to_display(command: Sequence[str]) -> str:

--- a/src/richterm/sphinxext.py
+++ b/src/richterm/sphinxext.py
@@ -14,7 +14,16 @@ from sphinx.errors import SphinxError
 from sphinx.util import logging
 
 from . import get_version
-from ._core import CommandExecutionError, RenderOptions, command_to_display, render_svg, run_command
+from ._core import (
+    CommandExecutionError,
+    InvalidThemeError,
+    RenderOptions,
+    command_to_display,
+    default_terminal_theme_name,
+    normalize_terminal_theme,
+    render_svg,
+    run_command,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -27,6 +36,7 @@ class RichTermDirective(Directive):
     final_argument_whitespace = True
     option_spec: ClassVar[dict[str, Callable[[str | None], object]]] = {
         "prompt": directives.unchanged,
+        "theme": directives.unchanged,
         "shown-command": directives.unchanged,
         "hide-command": directives.flag,
     }
@@ -35,15 +45,22 @@ class RichTermDirective(Directive):
     def _get_config(self) -> SimpleNamespace:
         env = getattr(self.state.document.settings, "env", None)
         if env is None:
-            return SimpleNamespace(richterm_prompt="$", richterm_hide_command=False, richterm_shown_command=None)
+            return SimpleNamespace(
+                richterm_prompt="$",
+                richterm_hide_command=False,
+                richterm_shown_command=None,
+                richterm_theme="default",
+            )
         config = getattr(env, "config", None)
         prompt = getattr(config, "richterm_prompt", "$")
         hide = getattr(config, "richterm_hide_command", False)
         shown_command = getattr(config, "richterm_shown_command", None)
+        theme = getattr(config, "richterm_theme", "default")
         return SimpleNamespace(
             richterm_prompt=prompt,
             richterm_hide_command=hide,
             richterm_shown_command=shown_command,
+            richterm_theme=theme,
         )
 
     def run(self) -> list[nodes.Node]:
@@ -54,6 +71,11 @@ class RichTermDirective(Directive):
         config = self._get_config()
         prompt = self.options.get("prompt", config.richterm_prompt)
         hide_command = "hide-command" in self.options or bool(config.richterm_hide_command)
+        theme_option = self.options.get("theme")
+        try:
+            theme = normalize_terminal_theme(theme_option or config.richterm_theme)
+        except InvalidThemeError as exc:
+            raise self.severe(str(exc)) from exc
         shown_command_option = self.options.get("shown-command")
         shown_command = shown_command_option if shown_command_option is not None else config.richterm_shown_command
         if hide_command and shown_command:
@@ -77,7 +99,7 @@ class RichTermDirective(Directive):
         svg = render_svg(
             command_display,
             transcript,
-            RenderOptions(prompt=prompt, hide_command=hide_command),
+            RenderOptions(prompt=prompt, hide_command=hide_command, theme=theme),
         )
 
         raw_node = nodes.raw("", svg, format="html")
@@ -94,6 +116,7 @@ def setup(app: Sphinx) -> dict[str, object]:
     app.add_config_value("richterm_prompt", "$", "env")
     app.add_config_value("richterm_hide_command", False, "env")
     app.add_config_value("richterm_shown_command", None, "env")
+    app.add_config_value("richterm_theme", default_terminal_theme_name(), "env")
     app.add_directive("richterm", RichTermDirective)
     return {
         "version": get_version(),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -83,6 +83,76 @@ def test_cli_shown_command_rejects_hide_command() -> None:
         main(["--shown-command", "echo pretend", "--hide-command", "echo", "hi"])
 
 
+def test_cli_theme_changes_svg_background(tmp_path: Path) -> None:
+    output_path = tmp_path / "monokai.svg"
+    exit_code = main(
+        [
+            "--theme",
+            "monokai",
+            "-o",
+            str(output_path),
+            "python",
+            "-c",
+            "print('hello')",
+        ]
+    )
+    assert exit_code == 0
+    svg = output_path.read_text(encoding="utf-8")
+    assert 'fill="#0c0c0c"' in svg
+
+
+def test_cli_theme_uses_environment_default(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("RICHTERM_THEME", "monokai")
+    output_path = tmp_path / "env-theme.svg"
+    exit_code = main(
+        [
+            "-o",
+            str(output_path),
+            "python",
+            "-c",
+            "print('hello')",
+        ]
+    )
+    assert exit_code == 0
+    svg = output_path.read_text(encoding="utf-8")
+    assert 'fill="#0c0c0c"' in svg
+
+
+def test_cli_theme_option_overrides_environment(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("RICHTERM_THEME", "monokai")
+    output_path = tmp_path / "override-theme.svg"
+    exit_code = main(
+        [
+            "--theme",
+            "svg-export",
+            "-o",
+            str(output_path),
+            "python",
+            "-c",
+            "print('hello')",
+        ]
+    )
+    assert exit_code == 0
+    svg = output_path.read_text(encoding="utf-8")
+    assert 'fill="#292929"' in svg
+    assert 'fill="#0c0c0c"' not in svg
+
+
+def test_cli_rejects_unknown_theme(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit):
+        main(["--theme", "unknown-theme", "echo", "hello"])
+    captured = capsys.readouterr()
+    assert "Unknown theme 'unknown-theme'" in captured.err
+
+
+def test_cli_rejects_unknown_theme_from_environment(capsys: pytest.CaptureFixture[str], monkeypatch) -> None:
+    monkeypatch.setenv("RICHTERM_THEME", "unknown-theme")
+    with pytest.raises(SystemExit):
+        main(["echo", "hello"])
+    captured = capsys.readouterr()
+    assert "Unknown theme 'unknown-theme'" in captured.err
+
+
 def test_cli_non_zero_exit_code(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     output_path = tmp_path / "failure.svg"
     exit_code = main(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -47,6 +47,7 @@ def test_render_svg_uses_selected_theme() -> None:
 def test_available_terminal_themes_are_stable() -> None:
     assert available_terminal_themes() == (
         "default",
+        "light",
         "monokai",
         "dimmed-monokai",
         "night-owlish",

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -19,6 +19,8 @@ from richterm._core import (
     run_command,
 )
 
+SVG_EXPORT_BACKGROUND_RED = 41
+
 
 def test_command_to_display_quotes_arguments() -> None:
     assert command_to_display(["echo", "hello world"]) == "echo 'hello world'"
@@ -68,7 +70,7 @@ def test_default_terminal_theme_name_from_environment(monkeypatch) -> None:
 
 def test_get_terminal_theme_returns_rich_terminal_theme() -> None:
     theme = get_terminal_theme("svg-export")
-    assert theme.background_color.red == 41
+    assert theme.background_color.red == SVG_EXPORT_BACKGROUND_RED
 
 
 def test_run_command_raises_for_missing_binary() -> None:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7,9 +7,14 @@ import pytest
 from richterm import _default_output_path
 from richterm._core import (
     CommandExecutionError,
+    InvalidThemeError,
     RenderOptions,
     _prepare_environment,
+    available_terminal_themes,
     command_to_display,
+    default_terminal_theme_name,
+    get_terminal_theme,
+    normalize_terminal_theme,
     render_svg,
     run_command,
 )
@@ -30,6 +35,40 @@ def test_render_svg_hides_command_when_requested() -> None:
     svg = render_svg("echo hi", "hi\n", RenderOptions(prompt="$", hide_command=True))
     assert "echo hi" not in svg
     assert "hi" in svg
+
+
+def test_render_svg_uses_selected_theme() -> None:
+    svg = render_svg("echo hi", "hi\n", RenderOptions(theme="monokai"))
+    assert 'fill="#0c0c0c"' in svg
+
+
+def test_available_terminal_themes_are_stable() -> None:
+    assert available_terminal_themes() == (
+        "default",
+        "monokai",
+        "dimmed-monokai",
+        "night-owlish",
+        "svg-export",
+    )
+
+
+def test_normalize_terminal_theme_accepts_aliases() -> None:
+    assert normalize_terminal_theme("DIMMED_MONOKAI") == "dimmed-monokai"
+
+
+def test_normalize_terminal_theme_rejects_unknown_name() -> None:
+    with pytest.raises(InvalidThemeError):
+        normalize_terminal_theme("does-not-exist")
+
+
+def test_default_terminal_theme_name_from_environment(monkeypatch) -> None:
+    monkeypatch.setenv("RICHTERM_THEME", "monokai")
+    assert default_terminal_theme_name() == "monokai"
+
+
+def test_get_terminal_theme_returns_rich_terminal_theme() -> None:
+    theme = get_terminal_theme("svg-export")
+    assert theme.background_color.red == 41
 
 
 def test_run_command_raises_for_missing_binary() -> None:

--- a/tests/test_sphinxext.py
+++ b/tests/test_sphinxext.py
@@ -41,11 +41,13 @@ def make_directive(  # noqa: PLR0913
     command: str,
     *,
     prompt: str | None = None,
+    theme: str | None = None,
     hide_option: bool = False,
     config_prompt: str = "$",
     config_hide: bool = False,
     shown_command: str | None = None,
     config_shown: str | None = None,
+    config_theme: str = "default",
     with_env: bool = True,
     builder_format: str | None = None,
 ) -> RichTermDirective:
@@ -57,6 +59,7 @@ def make_directive(  # noqa: PLR0913
                 richterm_prompt=config_prompt,
                 richterm_hide_command=config_hide,
                 richterm_shown_command=config_shown,
+                richterm_theme=config_theme,
             )
         )
         if builder_format is not None:
@@ -75,6 +78,8 @@ def make_directive(  # noqa: PLR0913
     options: dict[str, object] = {}
     if prompt is not None:
         options["prompt"] = RichTermDirective.option_spec["prompt"](prompt)
+    if theme is not None:
+        options["theme"] = RichTermDirective.option_spec["theme"](theme)
     if hide_option:
         options["hide-command"] = RichTermDirective.option_spec["hide-command"](None)
     if shown_command is not None:
@@ -99,8 +104,16 @@ def test_setup_registers_extension(mocker) -> None:
     app.add_config_value.assert_any_call("richterm_prompt", "$", "env")
     app.add_config_value.assert_any_call("richterm_hide_command", False, "env")
     app.add_config_value.assert_any_call("richterm_shown_command", None, "env")
+    app.add_config_value.assert_any_call("richterm_theme", "default", "env")
     app.add_directive.assert_called_with("richterm", RichTermDirective)
     assert config["version"] == get_version()
+
+
+def test_setup_uses_environment_theme_default(mocker, monkeypatch) -> None:
+    monkeypatch.setenv("RICHTERM_THEME", "monokai")
+    app = mocker.Mock()
+    setup(app)
+    app.add_config_value.assert_any_call("richterm_theme", "monokai", "env")
 
 
 def test_directive_renders_svg() -> None:
@@ -177,6 +190,39 @@ def test_directive_shown_command_ignored_when_hidden(mocker) -> None:
     mock_warning.assert_called_once()
 
 
+def test_directive_theme_option_changes_svg_background() -> None:
+    directive = make_directive(
+        "python -c \"print('hi')\"",
+        theme="monokai",
+    )
+    nodes = directive.run()
+    assert len(nodes) == 1
+    assert 'fill="#0c0c0c"' in nodes[0].astext()
+
+
+def test_directive_theme_from_config() -> None:
+    directive = make_directive(
+        "python -c \"print('hi')\"",
+        config_theme="svg-export",
+    )
+    nodes = directive.run()
+    assert len(nodes) == 1
+    assert 'fill="#292929"' in nodes[0].astext()
+
+
+def test_directive_theme_option_overrides_config() -> None:
+    directive = make_directive(
+        "python -c \"print('hi')\"",
+        theme="monokai",
+        config_theme="svg-export",
+    )
+    nodes = directive.run()
+    assert len(nodes) == 1
+    svg_text = nodes[0].astext()
+    assert 'fill="#0c0c0c"' in svg_text
+    assert 'fill="#292929"' not in svg_text
+
+
 def test_directive_failure_raises_sphinx_error() -> None:
     directive = make_directive('python -c "import sys; sys.exit(2)"')
     with pytest.raises(SphinxError):
@@ -196,6 +242,7 @@ def test_directive_defaults_without_env() -> None:
     assert config.richterm_prompt == "$"
     assert config.richterm_hide_command is False
     assert config.richterm_shown_command is None
+    assert config.richterm_theme == "default"
 
 
 def test_directive_requires_command() -> None:
@@ -206,6 +253,12 @@ def test_directive_requires_command() -> None:
 
 def test_directive_invalid_command_syntax() -> None:
     directive = make_directive('python -c "unterminated')
+    with pytest.raises(DirectiveError):
+        directive.run()
+
+
+def test_directive_invalid_theme() -> None:
+    directive = make_directive("python -c \"print('x')\"", theme="unknown-theme")
     with pytest.raises(DirectiveError):
         directive.run()
 

--- a/uv.lock
+++ b/uv.lock
@@ -3,11 +3,11 @@ revision = 3
 requires-python = ">=3.11"
 
 [options]
-exclude-newer = "2026-03-27T04:16:51.671895369Z"
+exclude-newer = "2026-03-27T19:17:51.179792971Z"
 exclude-newer-span = "P1W"
 
 [options.exclude-newer-package]
-ty = { timestamp = "2026-04-03T04:16:51.671917648Z", span = "PT0S" }
+ty = { timestamp = "2026-04-03T19:17:51.179802051Z", span = "PT0S" }
 
 [[package]]
 name = "accessible-pygments"
@@ -791,6 +791,7 @@ dev = [
     { name = "ruff" },
     { name = "sphinx" },
     { name = "sphinx-book-theme" },
+    { name = "sphinx-tabs" },
     { name = "sphinxcontrib-mermaid" },
     { name = "ty" },
 ]
@@ -799,6 +800,7 @@ docs = [
     { name = "richterm", extra = ["sphinx"] },
     { name = "sphinx" },
     { name = "sphinx-book-theme" },
+    { name = "sphinx-tabs" },
     { name = "sphinxcontrib-mermaid" },
 ]
 lint = [
@@ -836,6 +838,7 @@ dev = [
     { name = "ruff" },
     { name = "sphinx", specifier = ">=8.2" },
     { name = "sphinx-book-theme", specifier = ">=1.1.0" },
+    { name = "sphinx-tabs", specifier = ">=3.5.0" },
     { name = "sphinxcontrib-mermaid", specifier = ">=1.0.0" },
     { name = "ty", specifier = ">=0.0.27" },
 ]
@@ -844,6 +847,7 @@ docs = [
     { name = "richterm", extras = ["sphinx"], specifier = ">=0.1.0" },
     { name = "sphinx", specifier = ">=8.2" },
     { name = "sphinx-book-theme", specifier = ">=1.1.0" },
+    { name = "sphinx-tabs", specifier = ">=3.5.0" },
     { name = "sphinxcontrib-mermaid", specifier = ">=1.0.0" },
 ]
 lint = [{ name = "ruff" }]
@@ -959,6 +963,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/45/19/d002ed96bdc7738c15847c730e1e88282d738263deac705d5713b4d8fa94/sphinx_book_theme-1.1.4.tar.gz", hash = "sha256:73efe28af871d0a89bd05856d300e61edce0d5b2fbb7984e84454be0fedfe9ed", size = 439188, upload-time = "2025-02-20T16:32:32.581Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/51/9e/c41d68be04eef5b6202b468e0f90faf0c469f3a03353f2a218fd78279710/sphinx_book_theme-1.1.4-py3-none-any.whl", hash = "sha256:843b3f5c8684640f4a2d01abd298beb66452d1b2394cd9ef5be5ebd5640ea0e1", size = 433952, upload-time = "2025-02-20T16:32:31.009Z" },
+]
+
+[[package]]
+name = "sphinx-tabs"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docutils" },
+    { name = "pygments" },
+    { name = "sphinx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/30/ca5b0de830f369968d8e3483dd45a8908fd10169c05cd9837f0bd075982e/sphinx_tabs-3.5.0.tar.gz", hash = "sha256:91dba1187e4c35fd37380a56ac228bbd54c6c649b2351829f3bf033718277537", size = 17006, upload-time = "2026-03-03T23:00:30.404Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/45/6adc5efeb19fd5fed4027e520b5c668ce58236a2b271ade5533c4c116276/sphinx_tabs-3.5.0-py3-none-any.whl", hash = "sha256:154be49de4d5c8249ea08c5d9bf88ca8f9c31e00a178305a93cbc33e000339e5", size = 9871, upload-time = "2026-03-03T23:00:28.89Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This PR adds named SVG export theme selection across the project.

It includes:

- `--theme` in the CLI
- `:theme:` in the Sphinx directive
- `richterm_theme` as a global Sphinx config value
- `{term}`-documented `RICHTERM_THEME` as an environment default
- a tabbed docs example showing the same ANSI output with different themes

Closes #8.

## Testing

- `uv run pytest tests/test_core.py tests/test_cli.py tests/test_sphinxext.py`
- `uv run ty check`
- `make docs`
